### PR TITLE
feat(auth): complete forgot password flow in single route

### DIFF
--- a/apps/FlowerApp/src/app/app.routes.ts
+++ b/apps/FlowerApp/src/app/app.routes.ts
@@ -56,13 +56,13 @@ export const appRoutes: Route[] = [
       //       (e) => e.RegisterComponent
       //     ),
       // },
-      // {
-      //   path: 'forget-password',
-      //   loadComponent: () =>
-      //     import('./core/pages/forget-password/forget-password.component').then(
-      //       (e) => e.ForgetPasswordComponent
-      //     ),
-      // },
+      {
+        path: 'forget-password',
+        loadComponent: () =>
+          import(
+            './features/pages/forget-password/forget-password.component'
+          ).then((e) => e.ForgetPasswordComponent),
+      },
       // {
       //   path: 'verify-code',
       //   loadComponent: () =>

--- a/apps/FlowerApp/src/app/features/pages/forget-password/forget-password.component.html
+++ b/apps/FlowerApp/src/app/features/pages/forget-password/forget-password.component.html
@@ -1,11 +1,13 @@
+@if(!isEmailSend && !isCodeSend){
+
 <form
-  [formGroup]="loginForm"
-  (ngSubmit)="onSubmit()"
+  [formGroup]="forgetPasswordForm"
+  (ngSubmit)="sendEmail()"
   class="flex flex-column gap-3"
 >
-  <h3 class="text-center">Welcome back!</h3>
+  <h3>Forgot Password?</h3>
+  <p>Worry not, we’ll send you instructions to help you reset it.</p>
   <div class="line"></div>
-
   <!-- Email Input -->
   <label for="email" class="input-label">Email</label>
   <app-global-input
@@ -14,33 +16,15 @@
     placeholder="user@example.com"
     formControlName="email"
     [class.ng-invalid]="
-      loginForm.controls['email'].invalid && loginForm.controls['email'].touched
+      forgetPasswordForm.controls['email'].invalid &&
+      forgetPasswordForm.controls['email'].touched
     "
   ></app-global-input>
 
   <!-- Email Errors -->
   <app-field-error
-    [control]="loginForm.get('email')"
+    [control]="forgetPasswordForm.get('email')"
     [fieldName]="'email'"
-  ></app-field-error>
-
-  <!-- Password Input -->
-  <label for="password" class="input-label">Password</label>
-  <app-global-input
-    id="password"
-    type="password"
-    placeholder="********"
-    formControlName="password"
-    [class.ng-invalid]="
-      loginForm.controls['password'].invalid &&
-      loginForm.controls['password'].touched
-    "
-  ></app-global-input>
-
-  <!-- Password Errors -->
-  <app-field-error
-    [control]="loginForm.get('password')"
-    [fieldName]="'password'"
   ></app-field-error>
 
   <!-- Forgot Password Link -->
@@ -53,10 +37,10 @@
 
   <!-- Submit Button -->
   <app-primary-btn
-    [disabled]="loginForm.invalid"
+    [disabled]="forgetPasswordForm.invalid"
     type="submit"
     class="mb-3"
-    [labelName]="'Login'"
+    [labelName]="'Continue'"
     [displayIcon]="false"
     [widthFull]="true"
   ></app-primary-btn>
@@ -75,3 +59,8 @@
   <app-error [errorMessages]="[backendError]"></app-error>
   }
 </form>
+} @if (isEmailSend) {
+<app-verify-code (codeVerified)="onCodeVerified($event)"></app-verify-code>
+} @if(isCodeSend){
+<app-reset-password></app-reset-password>
+}

--- a/apps/FlowerApp/src/app/features/pages/forget-password/forget-password.component.scss
+++ b/apps/FlowerApp/src/app/features/pages/forget-password/forget-password.component.scss
@@ -1,0 +1,18 @@
+form {
+  h3 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 32px;
+    line-height: 57px;
+    color: var(--black-color);
+  }
+  a {
+    font-family: 'Sarabun-Regular';
+    font-style: normal;
+    font-weight: 600;
+    font-size: 14px;
+    line-height: 100%;
+
+    color: var(--maroon-700);
+  }
+}

--- a/apps/FlowerApp/src/app/features/pages/forget-password/forget-password.component.spec.ts
+++ b/apps/FlowerApp/src/app/features/pages/forget-password/forget-password.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ForgetPasswordComponent } from './forget-password.component';
+
+describe('ForgetPasswordComponent', () => {
+  let component: ForgetPasswordComponent;
+  let fixture: ComponentFixture<ForgetPasswordComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ForgetPasswordComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ForgetPasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/FlowerApp/src/app/features/pages/forget-password/forget-password.component.ts
+++ b/apps/FlowerApp/src/app/features/pages/forget-password/forget-password.component.ts
@@ -1,0 +1,91 @@
+import { Component, inject, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Subject, takeUntil } from 'rxjs';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { AuthApiService } from '@rose-flower/auth-api';
+import { GlobalInputComponent } from '../../../shared/components/ui/globalInput.component';
+import { FieldErrorComponent } from '../../../shared/components/business/fieldError/field-error.component';
+import { PrimaryBtnComponent } from '../../../shared/components/ui/primary-btn.component';
+import { RouterLink } from '@angular/router';
+import { ErrorComponent } from '../../../shared/components/ui/error/error.component';
+import { VerifyCodeComponent } from '../verify-code/verify-code.component';
+import { ResetPasswordComponent } from '../reset-password/reset-password.component';
+import { SharedDataService } from '../../../shared/services/shared-data.service';
+
+@Component({
+  selector: 'app-forget-password',
+  imports: [
+    CommonModule,
+    GlobalInputComponent,
+    FieldErrorComponent,
+    PrimaryBtnComponent,
+    RouterLink,
+    ErrorComponent,
+    ReactiveFormsModule,
+    VerifyCodeComponent,
+    ResetPasswordComponent,
+  ],
+  templateUrl: './forget-password.component.html',
+  styleUrl: './forget-password.component.scss',
+})
+export class ForgetPasswordComponent implements OnInit, OnDestroy {
+  private destroy$ = new Subject<void>();
+  forgetPasswordForm!: FormGroup;
+  isLoading: boolean = false;
+  isEmailSend: boolean = false;
+  isCodeSend: boolean = false;
+  backendError: string = '';
+  private readonly _authApiService = inject(AuthApiService);
+  private readonly _sharedDataService = inject(SharedDataService);
+  ngOnInit(): void {
+    this.initForm();
+    console.log(this.isCodeSend);
+  }
+
+  initForm(): void {
+    this.forgetPasswordForm = new FormGroup({
+      email: new FormControl(null, [Validators.required, Validators.email]),
+    });
+  }
+
+  sendEmail() {
+    if (this.forgetPasswordForm.invalid || this.isLoading) {
+      this.forgetPasswordForm.markAllAsTouched();
+    } else {
+      this.isLoading = true;
+
+      console.log(this.forgetPasswordForm.value);
+      const email = this.forgetPasswordForm.value.email;
+
+      this._sharedDataService.setEmail(email);
+      this._authApiService
+        .forgetPassword(this.forgetPasswordForm.value)
+        .pipe(takeUntil(this.destroy$))
+        .subscribe({
+          next: (res) => {
+            console.log(res);
+            this.isLoading = false;
+            this.isEmailSend = true;
+            // this._router.navigate(['/auth/verify-code']);
+          },
+          error: (err) => {
+            console.log(err);
+            this.isLoading = false;
+          },
+        });
+    }
+  }
+  onCodeVerified(success: boolean) {
+    this.isEmailSend = !success;
+    this.isCodeSend = success;
+  }
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/apps/FlowerApp/src/app/features/pages/login/login.component.ts
+++ b/apps/FlowerApp/src/app/features/pages/login/login.component.ts
@@ -1,4 +1,4 @@
- import { AuthApiService } from '@rose-flower/auth-api';
+import { AuthApiService } from '@rose-flower/auth-api';
 import { InputTextModule } from 'primeng/inputtext';
 import { Component, OnInit } from '@angular/core';
 import {
@@ -11,7 +11,7 @@ import {
 import { PasswordModule } from 'primeng/password';
 import { ButtonModule } from 'primeng/button';
 import { CommonModule } from '@angular/common';
-import { Router, RouterModule } from '@angular/router';
+import { Router, RouterLink, RouterModule } from '@angular/router';
 import { Subject, takeUntil } from 'rxjs';
 import { ErrorComponent } from '../../../shared/components/ui/error/error.component';
 import { TokenService } from '../../services/token.service';
@@ -19,7 +19,7 @@ import { PrimaryBtnComponent } from '../../../shared/components/ui/primary-btn.c
 import { GlobalInputComponent } from '../../../shared/components/ui/globalInput.component';
 import { AuthService } from '../../../shared/services/auth.service';
 import { LoginDTO } from 'auth-api/src/lib/auth-api/interfaces/login.dto';
-import { FieldErrorComponent } from "../../../shared/components/business/fieldError/field-error.component";
+import { FieldErrorComponent } from '../../../shared/components/business/fieldError/field-error.component';
 
 @Component({
   selector: 'app-login',
@@ -35,8 +35,9 @@ import { FieldErrorComponent } from "../../../shared/components/business/fieldEr
     PrimaryBtnComponent,
     GlobalInputComponent,
     PrimaryBtnComponent,
-    FieldErrorComponent
-],
+    FieldErrorComponent,
+    RouterLink,
+  ],
   templateUrl: './login.component.html',
   styleUrl: './login.component.scss',
 })

--- a/apps/FlowerApp/src/app/features/pages/reset-password/reset-password.component.html
+++ b/apps/FlowerApp/src/app/features/pages/reset-password/reset-password.component.html
@@ -1,0 +1,71 @@
+<form
+  [formGroup]="resetPasswordForm"
+  (ngSubmit)="setNewPassword()"
+  class="flex flex-column gap-3"
+>
+  <h3>Create a new password</h3>
+  <p>Set a strong password to secure your account.</p>
+  <div class="line"></div>
+
+  <!-- Password Input -->
+  <label for="password" class="input-label">Password</label>
+  <app-global-input
+    id="password"
+    type="password"
+    placeholder="********"
+    formControlName="password"
+    [class.ng-invalid]="
+      resetPasswordForm.controls['password'].invalid &&
+      resetPasswordForm.controls['password'].touched
+    "
+  ></app-global-input>
+
+  <!-- Password Errors -->
+  <app-field-error
+    [control]="resetPasswordForm.get('password')"
+    [fieldName]="'password'"
+  ></app-field-error>
+
+  <!-- Password Input -->
+  <label for="rePassword" class="input-label">Confirm Password</label>
+  <app-global-input
+    id="rePassword"
+    type="password"
+    placeholder="********"
+    formControlName="newPassword"
+    [class.ng-invalid]="
+      resetPasswordForm.controls['newPassword'].invalid &&
+      resetPasswordForm.controls['newPassword'].touched
+    "
+  ></app-global-input>
+
+  <!-- Password Errors -->
+  <app-field-error
+    [control]="resetPasswordForm.get('newPassword')"
+    [fieldName]="'newPassword'"
+  ></app-field-error>
+
+  <!-- Submit Button -->
+  <app-primary-btn
+    [disabled]="resetPasswordForm.invalid"
+    type="submit"
+    class="mb-3"
+    [labelName]="'Reset Password'"
+    [displayIcon]="false"
+    [widthFull]="true"
+  ></app-primary-btn>
+
+  <!-- Divider -->
+  <div class="line"></div>
+
+  <!-- Sign up redirect -->
+  <p class="text-center text-sm">
+    Need help?
+    <a [routerLink]="['/auth/signup']">Contact us</a>
+  </p>
+
+  <!-- Backend Error -->
+  @if (backendError.length>0) {
+  <app-error [errorMessages]="[backendError]"></app-error>
+  }
+</form>

--- a/apps/FlowerApp/src/app/features/pages/reset-password/reset-password.component.scss
+++ b/apps/FlowerApp/src/app/features/pages/reset-password/reset-password.component.scss
@@ -1,0 +1,23 @@
+form {
+  h3 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 32px;
+    line-height: 57px;
+    color: var(--black-color);
+  }
+  a {
+    color: black;
+  }
+  p {
+    a {
+      font-family: 'Sarabun-Regular';
+      font-style: normal;
+      font-weight: 600;
+      font-size: 14px;
+      line-height: 100%;
+
+      color: var(--maroon-700);
+    }
+  }
+}

--- a/apps/FlowerApp/src/app/features/pages/reset-password/reset-password.component.spec.ts
+++ b/apps/FlowerApp/src/app/features/pages/reset-password/reset-password.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ResetPasswordComponent } from './reset-password.component';
+
+describe('ResetPasswordComponent', () => {
+  let component: ResetPasswordComponent;
+  let fixture: ComponentFixture<ResetPasswordComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ResetPasswordComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ResetPasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/FlowerApp/src/app/features/pages/reset-password/reset-password.component.ts
+++ b/apps/FlowerApp/src/app/features/pages/reset-password/reset-password.component.ts
@@ -1,0 +1,98 @@
+import { Component, inject, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { Subject, takeUntil } from 'rxjs';
+import { AuthApiService } from '@rose-flower/auth-api';
+
+import { GlobalInputComponent } from '../../../shared/components/ui/globalInput.component';
+import { FieldErrorComponent } from '../../../shared/components/business/fieldError/field-error.component';
+import { PrimaryBtnComponent } from '../../../shared/components/ui/primary-btn.component';
+import { ErrorComponent } from '../../../shared/components/ui/error/error.component';
+import { Router, RouterLink } from '@angular/router';
+import { SharedDataService } from '../../../shared/services/shared-data.service';
+
+@Component({
+  selector: 'app-reset-password',
+  imports: [
+    CommonModule,
+    GlobalInputComponent,
+    FieldErrorComponent,
+    PrimaryBtnComponent,
+    ErrorComponent,
+    RouterLink,
+    ReactiveFormsModule,
+  ],
+  templateUrl: './reset-password.component.html',
+  styleUrl: './reset-password.component.scss',
+})
+export class ResetPasswordComponent implements OnInit, OnDestroy {
+  resetPasswordForm!: FormGroup;
+  isLoading: boolean = false;
+  backendError: string = '';
+  private readonly destroy$ = new Subject<void>();
+  private readonly _authApiService = inject(AuthApiService);
+  private readonly _router = inject(Router);
+  private readonly _sharedDataService = inject(SharedDataService);
+  email = this._sharedDataService.getEmail();
+  constructor() {}
+  ngOnInit(): void {
+    this.initForm();
+  }
+
+  initForm(): void {
+    this.resetPasswordForm = new FormGroup({
+      password: new FormControl(null, [
+        Validators.required,
+        Validators.pattern(
+          /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,}$/
+        ),
+      ]),
+      newPassword: new FormControl(null, [
+        Validators.required,
+        Validators.pattern(
+          /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,}$/
+        ),
+      ]),
+    });
+  }
+
+  setNewPassword() {
+    console.log(this.resetPasswordForm.value);
+    if (this.resetPasswordForm.invalid || this.isLoading) {
+      this.resetPasswordForm.markAllAsTouched();
+    } else {
+      const payload = {
+        email: this.email,
+        newPassword: this.resetPasswordForm.value.newPassword,
+        password: this.resetPasswordForm.value.password,
+      };
+      this.isLoading = true;
+      console.log(this.resetPasswordForm.value);
+      this._authApiService
+        .resetPassword(payload)
+        .pipe(takeUntil(this.destroy$))
+        .subscribe({
+          next: (res) => {
+            console.log(res);
+            this.isLoading = false;
+            this._sharedDataService.clearEmail();
+            this._router.navigate(['/auth/login']);
+          },
+          error: (err) => {
+            console.log(err);
+            this.isLoading = false;
+          },
+        });
+    }
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/apps/FlowerApp/src/app/features/pages/verify-code/verify-code.component.html
+++ b/apps/FlowerApp/src/app/features/pages/verify-code/verify-code.component.html
@@ -1,0 +1,54 @@
+<form
+  [formGroup]="verifyCodeForm"
+  (ngSubmit)="verifyCode()"
+  class="flex flex-column gap-3"
+>
+  <h3>Enter the OTP Code</h3>
+  <!-- <p>We have sent a 6-digit code to user@example.com Edit</p> -->
+  <div class="line"></div>
+
+  <app-global-input
+    id="verificationCode"
+    type="text"
+    placeholder="Enter Number"
+    formControlName="resetCode"
+    [class.ng-invalid]="
+      verifyCodeForm.controls['resetCode'].invalid &&
+      verifyCodeForm.controls['resetCode'].touched
+    "
+  ></app-global-input>
+
+  <!-- Email Errors -->
+  <app-field-error
+    [control]="verifyCodeForm.get('resetCode')"
+    [fieldName]="'resetCode'"
+  ></app-field-error>
+
+  <!-- Forgot Password Link -->
+  <a [routerLink]="['/auth/forget-password']" class="w-full mb-3 text-right">
+    Send a new code
+  </a>
+
+  <!-- Submit Button -->
+  <app-primary-btn
+    [disabled]="verifyCodeForm.invalid"
+    type="submit"
+    class="mb-3"
+    [labelName]="'Verify OTP'"
+    [displayIcon]="false"
+    [widthFull]="true"
+  ></app-primary-btn>
+
+  <!-- Divider -->
+  <div class="line"></div>
+
+  <p class="text-center text-sm">
+    Need help?
+    <a [routerLink]="['/auth/signup']">Contact us</a>
+  </p>
+
+  <!-- Backend Error -->
+  @if (backendError.length>0) {
+  <app-error [errorMessages]="[backendError]"></app-error>
+  }
+</form>

--- a/apps/FlowerApp/src/app/features/pages/verify-code/verify-code.component.scss
+++ b/apps/FlowerApp/src/app/features/pages/verify-code/verify-code.component.scss
@@ -1,0 +1,25 @@
+form {
+  h3 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 32px;
+    line-height: 57px;
+    color: var(--black-color);
+  }
+  a {
+    color: var(--black-color);
+  }
+  p {
+    a {
+      /* Primary/Semi-Bold/primary-semibold-sm */
+      font-family: 'Sarabun-Regular';
+      font-style: normal;
+      font-weight: 600;
+      font-size: 14px;
+      line-height: 100%;
+
+      /* Maroon/maroon-700 */
+      color: var(--maroon-700);
+    }
+  }
+}

--- a/apps/FlowerApp/src/app/features/pages/verify-code/verify-code.component.spec.ts
+++ b/apps/FlowerApp/src/app/features/pages/verify-code/verify-code.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { VerifyCodeComponent } from './verify-code.component';
+
+describe('VerifyCodeComponent', () => {
+  let component: VerifyCodeComponent;
+  let fixture: ComponentFixture<VerifyCodeComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [VerifyCodeComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(VerifyCodeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/FlowerApp/src/app/features/pages/verify-code/verify-code.component.ts
+++ b/apps/FlowerApp/src/app/features/pages/verify-code/verify-code.component.ts
@@ -1,0 +1,85 @@
+import {
+  Component,
+  EventEmitter,
+  inject,
+  OnDestroy,
+  OnInit,
+  Output,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Subject, takeUntil } from 'rxjs';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { AuthApiService } from '@rose-flower/auth-api';
+import { GlobalInputComponent } from '../../../shared/components/ui/globalInput.component';
+import { FieldErrorComponent } from '../../../shared/components/business/fieldError/field-error.component';
+import { Router, RouterLink } from '@angular/router';
+import { PrimaryBtnComponent } from '../../../shared/components/ui/primary-btn.component';
+import { ErrorComponent } from '../../../shared/components/ui/error/error.component';
+
+@Component({
+  selector: 'app-verify-code',
+  imports: [
+    CommonModule,
+    GlobalInputComponent,
+    FieldErrorComponent,
+    RouterLink,
+    PrimaryBtnComponent,
+    ErrorComponent,
+    ReactiveFormsModule,
+  ],
+  templateUrl: './verify-code.component.html',
+  styleUrl: './verify-code.component.scss',
+})
+export class VerifyCodeComponent implements OnInit, OnDestroy {
+  verifyCodeForm!: FormGroup;
+  isLoading: boolean = false;
+  backendError: string = '';
+  @Output() codeVerified = new EventEmitter<boolean>();
+  private readonly destroy$ = new Subject<void>();
+  private readonly _authApiService = inject(AuthApiService);
+  private readonly _router = inject(Router);
+  constructor() {}
+  ngOnInit(): void {
+    this.initForm();
+  }
+
+  initForm(): void {
+    this.verifyCodeForm = new FormGroup({
+      resetCode: new FormControl(null, [Validators.required]),
+    });
+  }
+
+  verifyCode() {
+    if (this.verifyCodeForm.invalid || this.isLoading) {
+      this.verifyCodeForm.markAllAsTouched();
+    } else {
+      this.isLoading = true;
+      console.log(this.verifyCodeForm.value);
+      this._authApiService
+        .verifyCode(this.verifyCodeForm.value)
+        .pipe(takeUntil(this.destroy$))
+        .subscribe({
+          next: (res: any) => {
+            console.log(res);
+            this.isLoading = false;
+            this.codeVerified.emit(true);
+            // this._router.navigate(['/auth/reset-password']);
+          },
+          error: (err: any) => {
+            console.log(err);
+            this.isLoading = false;
+          },
+        });
+    }
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/apps/FlowerApp/src/app/shared/services/shared-data.service.ts
+++ b/apps/FlowerApp/src/app/shared/services/shared-data.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SharedDataService {
+  private emailSignal = signal<string>('');
+
+  setEmail(email: string) {
+    this.emailSignal.set(email);
+  }
+
+  getEmail() {
+    return this.emailSignal();
+  }
+
+  clearEmail() {
+    this.emailSignal.set('');
+  }
+}


### PR DESCRIPTION
• Implemented all reset steps in one route:
  - Email input
  - OTP verification
  - New password setup

• Added shared auth service to:
  - Store/transfer email between components
  - Handle backend communication
  - Manage reset state